### PR TITLE
ci: fix release metadata verification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,8 @@ jobs:
         shell: bash
         run: |
           version="${GITHUB_REF_NAME#v}"
-          test "$(python -m setuptools_scm)" = "$version"
+          installed_version="$(python -c "from importlib.metadata import version; print(version('pymaftools'))")"
+          test "$installed_version" = "$version"
           grep -q "^version: $version$" CITATION.cff
           grep -q "Version $version" CHANGELOG.md
 


### PR DESCRIPTION
## Summary

- verify the freshly installed `pymaftools` distribution version in the release quality job
- avoid assuming that the isolated PEP 517 build dependency `setuptools-scm` is installed as a global CLI

## Root cause

The v0.5.0 release stopped before building or publishing artifacts because the quality job invoked `python -m setuptools_scm`. Editable installation uses `setuptools-scm` inside an isolated build environment, but does not install that module into the job environment.

## Validation

- workflow YAML parses successfully
- the normal Tests and Docs PR gates must pass before merge
- the build job retains its independent tag-derived `setuptools_scm` check
