### PR TITLE
ci: harden and document the release process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
           installed_version="$(python -c "from importlib.metadata import version; print(version('pymaftools'))")"
           test "$installed_version" = "$version"
           grep -q "^version: $version$" CITATION.cff
-          grep -q "Version $version" CHANGELOG.md
+          python scripts/extract_release_notes.py "$version" --output release-notes.md
 
       - name: Lint and format
         run: |
@@ -171,17 +171,24 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v6
+
       - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
+
+      - name: Extract release notes
+        run: >-
+          python scripts/extract_release_notes.py "${GITHUB_REF_NAME#v}"
+          --output release-notes.md
 
       - name: Create GitHub Release
         run: >-
           gh release create "$GITHUB_REF_NAME" dist/*
           --verify-tag
           --title "pymaftools ${GITHUB_REF_NAME#v}"
-          --generate-notes
+          --notes-file release-notes.md
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,11 +87,25 @@ jobs:
       - name: Check package
         run: twine check dist/*
 
+      - name: Generate checksums
+        run: |
+          mkdir checksums
+          cd dist
+          sha256sum * > ../checksums/SHA256SUMS
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload checksums
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-checksums
+          path: checksums/SHA256SUMS
           if-no-files-found: error
           retention-days: 14
 
@@ -108,6 +122,14 @@ jobs:
         with:
           name: dist
           path: dist/
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: release-checksums
+          path: checksums/
+
+      - name: Verify build artifacts
+        run: cd dist && sha256sum --check ../checksums/SHA256SUMS
 
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -177,6 +199,14 @@ jobs:
           name: dist
           path: dist/
 
+      - uses: actions/download-artifact@v8
+        with:
+          name: release-checksums
+          path: checksums/
+
+      - name: Verify build artifacts
+        run: cd dist && sha256sum --check ../checksums/SHA256SUMS
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
@@ -193,6 +223,11 @@ jobs:
           name: dist
           path: dist/
 
+      - uses: actions/download-artifact@v8
+        with:
+          name: release-checksums
+          path: checksums/
+
       - name: Extract release notes
         run: >-
           python scripts/extract_release_notes.py "${GITHUB_REF_NAME#v}"
@@ -200,7 +235,7 @@ jobs:
 
       - name: Create GitHub Release
         run: >-
-          gh release create "$GITHUB_REF_NAME" dist/*
+          gh release create "$GITHUB_REF_NAME" dist/* checksums/SHA256SUMS
           --verify-tag
           --title "pymaftools ${GITHUB_REF_NAME#v}"
           --notes-file release-notes.md

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,23 +122,38 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install package from TestPyPI
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+
+      - name: Download package from TestPyPI
         shell: bash
         run: |
           version="${GITHUB_REF_NAME#v}"
+          mkdir -p testpypi
           for attempt in {1..10}; do
-            if python -m pip install --no-cache-dir \
+            if python -m pip download --no-cache-dir --no-deps --only-binary=:all: \
               --index-url https://test.pypi.org/simple/ \
-              --extra-index-url https://pypi.org/simple/ \
-              "pymaftools==$version"; then
+              --dest testpypi/ "pymaftools==$version"; then
               exit 0
             fi
             if [[ "$attempt" -eq 10 ]]; then
-              echo "TestPyPI package was not installable after 10 attempts." >&2
+              echo "TestPyPI wheel was not available after 10 attempts." >&2
               exit 1
             fi
             sleep 15
           done
+
+      - name: Verify and install TestPyPI artifact
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          built_wheel="dist/pymaftools-${version}-py3-none-any.whl"
+          testpypi_wheel="testpypi/pymaftools-${version}-py3-none-any.whl"
+          cmp "$built_wheel" "$testpypi_wheel"
+          python -m pip install --no-cache-dir \
+            --index-url https://pypi.org/simple/ "$testpypi_wheel"
 
       - name: Smoke-test installed HDF5 workflow
         run: >-

--- a/RELEASE_AUDIT.md
+++ b/RELEASE_AUDIT.md
@@ -74,6 +74,7 @@ Repository controls verified on 2026-07-15:
 | O10 | Low | **The changelog can contain relative links that do not resolve correctly in a GitHub Release body.** Review links before tagging and prefer absolute repository URLs in release sections. |
 | O11 | Low | **Experimental Python 3.13 and 3.14 jobs may fail without blocking merge.** Their output must be reviewed, and a supported-version change must update the matrix and metadata together. |
 | O12 | Low | **Tags are not protected by a repository ruleset and commits are not required to be signed.** Branch protection, tag validation, and the PyPI approval gate are sufficient for the current single-maintainer model. Revisit for multiple maintainers. |
+| O13 | Low | **A push to `dev` with an open PR starts duplicate Tests runs.** One run comes from the branch push and one from the pull request event. Keep both for immediate branch feedback today; narrow push branches or add event-aware concurrency if runner usage becomes material. |
 
 ### Deferred by Design
 

--- a/RELEASE_AUDIT.md
+++ b/RELEASE_AUDIT.md
@@ -1,0 +1,134 @@
+# Release Process Audit
+
+Last reviewed: 2026-07-15
+
+This document audits the release path for `pymaftools`. It separates controls in
+the repository from settings that live in GitHub, TestPyPI, and PyPI. The
+operational checklist is in `RELEASE_CHECKLIST.md`.
+
+## Current Release Path
+
+1. A pull request merges release metadata and code into `main` after required
+   Tests and Docs checks pass.
+2. An annotated `vX.Y.Z` tag starts `.github/workflows/publish.yml`.
+3. The workflow validates the tag syntax, `main` ancestry, setuptools-scm
+   version, `CITATION.cff`, and the matching `CHANGELOG.md` section.
+4. Ruff, the test suite, coverage, and warning-free Sphinx documentation run
+   again from the tagged commit.
+5. The workflow builds one wheel and one sdist, runs `twine check`, records their
+   SHA256 hashes, and stores them as Actions artifacts.
+6. The exact artifacts are published to TestPyPI with OIDC. The wheel is then
+   downloaded without dependencies, compared byte-for-byte with the build
+   artifact, and installed with dependencies obtained only from PyPI.
+7. The HDF5 example workflow is smoke-tested from the installed wheel.
+8. The protected `pypi` environment waits for approval, verifies the saved
+   checksums, and publishes the same artifacts to PyPI with OIDC.
+9. A GitHub Release is created from the matching changelog section with the
+   wheel, sdist, and `SHA256SUMS` attached.
+
+Local `deploy.sh` only builds and validates. It has no upload credentials or
+upload command.
+
+## Controls Verified
+
+Repository controls verified on 2026-07-15:
+
+- `main` requires a pull request, strict required checks, resolved review
+  conversations, and applies protection to administrators.
+- Force pushes and branch deletion are disabled on `main`.
+- Required checks cover Ruff, Python 3.10-3.12, minimum pandas, package build,
+  and documentation build.
+- `testpypi` and `pypi` environments accept deployments only from `v*` tags.
+- `pypi` requires approval by `xu62u4u6`; self-approval is allowed. This is an
+  intentional confirmation gate, not independent two-person review.
+- TestPyPI and PyPI Trusted Publishers are proven operational by the successful
+  OIDC release of 0.5.0. Their configuration is external to this repository.
+- Release 0.5.0 completed the full quality, build, TestPyPI, installed HDF5
+  smoke, PyPI, and GitHub Release sequence.
+
+## Findings
+
+### Addressed
+
+| ID | Risk | Control |
+| --- | --- | --- |
+| A1 | GitHub-generated notes reduced a large release to PR titles. | Release notes are extracted from the exact `CHANGELOG.md` version section; missing, duplicate, or empty sections fail validation. |
+| A2 | TestPyPI installation used two indexes, so package and dependency origin was ambiguous. | The target wheel is downloaded from TestPyPI with `--no-deps`, compared to the build artifact, then installed with dependencies from PyPI only. |
+| A3 | Consumers could not easily confirm that GitHub assets matched the built distributions. | The pipeline verifies and publishes `SHA256SUMS`; the TestPyPI wheel is also compared byte-for-byte. |
+| A4 | Release metadata verification depended on an undeclared setuptools-scm CLI. | The quality job checks the installed distribution version through `importlib.metadata`; the build job installs its build tools explicitly. |
+| A5 | A local publishing script could bypass protected environments. | `deploy.sh` is build-only, and publishing is restricted to OIDC environments. |
+
+### Open Operational Risks
+
+| ID | Priority | Risk and current decision |
+| --- | --- | --- |
+| O1 | High | **Partial publication is not automatically recoverable.** Package index files are immutable. Use the recovery matrix below; never rebuild or replace an artifact after PyPI accepted it. |
+| O2 | Medium | **Final PyPI retrieval is manual.** The pipeline validates TestPyPI before promotion, but does not download the final PyPI files and compare them to `SHA256SUMS`. Keep the post-release check mandatory; automate it if releases become frequent. |
+| O3 | Medium | **Any ancestor of `main` can be tagged.** This supports deliberate maintenance releases but also permits an accidentally stale commit. The checklist requires updating `main` and reviewing the tag target. Enforce equality with `origin/main` if maintenance tags are never needed. |
+| O4 | Medium | **Release runs have no global concurrency group.** Two different version tags can progress concurrently. Do not push a second release tag while one is active; add a non-cancelling global release concurrency group if release frequency increases. |
+| O5 | Medium | **GitHub and package-index settings can drift outside Git.** Environment reviewers, tag filters, branch protection, and Trusted Publishers require a manual audit before each minor release. |
+| O6 | Medium | **Third-party Actions use mutable major-version tags.** This is normal and maintainable, but a compromised upstream tag is a supply-chain risk. Pin Actions to full commit SHAs and enable Dependabot updates if stronger assurance is required. |
+| O7 | Low | **Build inputs are bounded but not fully locked.** Runner images, apt packages, pip, and build dependencies can change. A constraints file or locked release environment would improve reproducibility at maintenance cost. |
+| O8 | Low | **Only the wheel is installation-smoke-tested.** The sdist receives metadata validation but is not built and imported in a fresh environment. Add an sdist install test if downstream source builds become important. |
+| O9 | Low | **Documentation follows `main`, not release versions.** The public docs may describe unreleased changes after development resumes. Versioned documentation is useful only when API release cadence justifies its upkeep. |
+| O10 | Low | **The changelog can contain relative links that do not resolve correctly in a GitHub Release body.** Review links before tagging and prefer absolute repository URLs in release sections. |
+| O11 | Low | **Experimental Python 3.13 and 3.14 jobs may fail without blocking merge.** Their output must be reviewed, and a supported-version change must update the matrix and metadata together. |
+| O12 | Low | **Tags are not protected by a repository ruleset and commits are not required to be signed.** Branch protection, tag validation, and the PyPI approval gate are sufficient for the current single-maintainer model. Revisit for multiple maintainers. |
+
+### Deferred by Design
+
+- GitHub artifact attestations and SBOM publication are not enabled. OIDC Trusted
+  Publishing, build-once promotion, exact wheel comparison, and checksums are
+  proportionate today. Attestations become useful when consumers will actually
+  verify them or when the project has stronger supply-chain requirements.
+- Independent reviewer approval is not required. The current `pypi` reviewer is
+  the maintainer and self-review is allowed, so the gate prevents accidental
+  publication but does not protect against a compromised maintainer account.
+
+## Failure Recovery Matrix
+
+First determine whether the version exists on TestPyPI or PyPI. Do not move or
+recreate a tag until this is known.
+
+| Failure point | Recovery |
+| --- | --- |
+| Before any TestPyPI upload | Fix through a pull request. If the old tag never published anywhere, delete and recreate it only after confirming both indexes are empty. A new patch version is still the safer option. |
+| After TestPyPI, before PyPI | Use **Re-run failed jobs** when no workflow change is required. If code or workflow changes are required, release a new patch version because TestPyPI already owns the old filename. |
+| During PyPI upload | Check the PyPI project page and JSON API first. If any file exists, treat the version as published and never reuse it. Diagnose whether all expected files arrived before deciding the next action. |
+| After PyPI, before GitHub Release | Do not rebuild. Recover the exact wheel and sdist from the retained Actions artifact or PyPI, verify `SHA256SUMS`, and create or repair the GitHub Release manually. |
+| GitHub Release exists but notes/assets are wrong | Edit the release notes or use `gh release upload --clobber` only with files whose hashes match the published PyPI artifacts. The tag and PyPI version remain unchanged. |
+| Documentation deployment fails | Fix Docs through a pull request and redeploy `main`. Do not republish the package. |
+
+## External Configuration Audit
+
+Before each minor release, verify:
+
+```bash
+gh api repos/xu62u4u6/pymaftools/branches/main/protection
+gh api repos/xu62u4u6/pymaftools/environments
+gh api repos/xu62u4u6/pymaftools/environments/testpypi/deployment-branch-policies
+gh api repos/xu62u4u6/pymaftools/environments/pypi/deployment-branch-policies
+```
+
+GitHub cannot confirm the package-index Trusted Publisher configuration. Check
+the TestPyPI and PyPI project publishing settings directly. They must name:
+
+- owner: `xu62u4u6`
+- repository: `pymaftools`
+- workflow: `publish.yml`
+- environments: `testpypi` and `pypi`, respectively
+
+Also confirm that no long-lived PyPI tokens remain in GitHub secrets or local
+automation.
+
+## Improvement Trigger Points
+
+Avoid adding controls without a concrete need:
+
+- Add final-PyPI automated hash verification after another release requires
+  manual recovery or when releases become routine.
+- Add global release concurrency before multiple release branches or maintainers
+  can publish tags concurrently.
+- Pin Actions by SHA when Dependabot is configured to keep those pins current.
+- Add attestations when a consumer or policy will verify them.
+- Add versioned docs when `main` regularly gets ahead of the latest public API.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -2,6 +2,8 @@
 
 Every release must use `.github/workflows/publish.yml`. Local commands build and
 validate artifacts only; they must never upload to TestPyPI or PyPI.
+Known risks, recovery procedures, and deferred improvements are documented in
+`RELEASE_AUDIT.md`.
 
 ## 0. One-Time Repository Configuration
 
@@ -21,6 +23,8 @@ Before opening the release pull request:
 
 - [ ] `CITATION.cff` has `version: X.Y.Z` and the correct release date.
 - [ ] `CHANGELOG.md` has a `Version X.Y.Z` section at the top.
+- [ ] Release-note links in that changelog section work outside the repository
+      file view; prefer absolute URLs.
 - [ ] `.claude/skills/pymaftools/SKILL.md` reflects public API changes.
 - [ ] `README.md` and `docs/` reflect public API changes.
 - [ ] `DATA_SOURCES.md` provenance and checksums cover bundled data changes.
@@ -46,6 +50,7 @@ pytest tests/ -v --tb=short --cov=pymaftools --cov-fail-under=60
 ruff check pymaftools/
 ruff format --check pymaftools/
 sphinx-build -W --keep-going docs docs/_build/html
+python scripts/extract_release_notes.py X.Y.Z --output /tmp/release-notes.md
 ```
 
 ## 3. Local Artifact Verification
@@ -74,28 +79,40 @@ After the release pull request is merged and `main` CI is green:
 ```bash
 git switch main
 git pull --ff-only origin main
+git status --short
 git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 ```
+
+Before pushing, confirm `git status` is empty, `git rev-parse HEAD` is the commit
+intended for release, and the exact version does not already exist on TestPyPI or
+PyPI. Do not push another release tag while a release workflow is active.
 
 The tag starts one protected pipeline that:
 
 1. Verifies the exact `vX.Y.Z` tag, release metadata, and `main` ancestry.
 2. Re-runs Ruff, tests, coverage, and warning-free Sphinx documentation.
-3. Builds wheel and sdist once and runs `twine check`.
+3. Builds wheel and sdist once, runs `twine check`, and records SHA256 checksums.
 4. Publishes that artifact to TestPyPI with OIDC Trusted Publishing.
-5. Installs the exact TestPyPI version and smoke-tests the bundled HDF5 table.
+5. Downloads the TestPyPI wheel without dependencies, compares it byte-for-byte
+   with the build artifact, installs dependencies only from PyPI, and smoke-tests
+   the bundled HDF5 table.
 6. Waits for approval on the protected `pypi` environment.
-7. Publishes the same artifact to PyPI with OIDC Trusted Publishing.
-8. Creates the GitHub Release and attaches wheel and sdist.
+7. Verifies checksums and publishes the same artifacts to PyPI with OIDC Trusted
+   Publishing.
+8. Creates the GitHub Release from the matching changelog section and attaches
+   wheel, sdist, and `SHA256SUMS`.
 
-Never run `twine upload` manually. A failed release should be diagnosed and
-re-tagged with a new version; published package files are immutable.
+Never run `twine upload` manually. Published package files are immutable. Follow
+the failure recovery matrix in `RELEASE_AUDIT.md`; whether a tag can be recreated
+depends on whether TestPyPI or PyPI accepted any file.
 
 ## 5. Post-Release
 
 - [ ] `pip install pymaftools==X.Y.Z` succeeds from PyPI.
 - [ ] The bundled HDF5 example loads from the installed wheel.
-- [ ] The GitHub Release contains wheel and sdist.
+- [ ] PyPI contains both wheel and sdist, and their hashes match `SHA256SUMS`.
+- [ ] The GitHub Release contains wheel, sdist, `SHA256SUMS`, and the complete
+      changelog section for this version.
 - [ ] Documentation is deployed at `https://dionic.xyz/pymaftools/`.
 - [ ] Commits after the tag receive the next setuptools-scm development version.

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -1,0 +1,72 @@
+"""Extract one version section from CHANGELOG.md for a GitHub Release."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+VERSION_PATTERN = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+VERSION_HEADING_PATTERN = re.compile(
+    r"^## .*?\bVersion\s+([0-9]+\.[0-9]+\.[0-9]+)(?:\s|$)"
+)
+
+
+def extract_release_notes(changelog: str, version: str) -> str:
+    """Return the changelog body for exactly one semantic version."""
+    if not VERSION_PATTERN.fullmatch(version):
+        raise ValueError(f"Version must match X.Y.Z: {version}")
+
+    lines = changelog.splitlines()
+    matches = [
+        index
+        for index, line in enumerate(lines)
+        if (match := VERSION_HEADING_PATTERN.match(line)) and match.group(1) == version
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"Expected exactly one changelog section for {version}, found {len(matches)}"
+        )
+
+    start = matches[0] + 1
+    end = next(
+        (
+            index
+            for index in range(start, len(lines))
+            if VERSION_HEADING_PATTERN.match(lines[index])
+        ),
+        len(lines),
+    )
+    section = lines[start:end]
+
+    while section and not section[-1].strip():
+        section.pop()
+    if section and section[-1].strip() == "---":
+        section.pop()
+    while section and not section[-1].strip():
+        section.pop()
+    while section and not section[0].strip():
+        section.pop(0)
+
+    notes = "\n".join(section)
+    if not notes:
+        raise ValueError(f"Changelog section for {version} is empty")
+    return f"{notes}\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version", help="Release version without the v prefix")
+    parser.add_argument("--changelog", type=Path, default=Path("CHANGELOG.md"))
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    notes = extract_release_notes(
+        args.changelog.read_text(encoding="utf-8"), args.version
+    )
+    args.output.write_text(notes, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_release_notes.py
+++ b/tests/test_release_notes.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.extract_release_notes import extract_release_notes
+
+
+CHANGELOG = """# Changelog
+
+## Version 1.2.0 (July 2026)
+
+Summary.
+
+### Changes
+* Added a feature.
+
+---
+
+## Version 1.1.0 (June 2026)
+
+Previous notes.
+"""
+
+
+def test_extract_release_notes_returns_only_requested_version() -> None:
+    notes = extract_release_notes(CHANGELOG, "1.2.0")
+
+    assert notes == "Summary.\n\n### Changes\n* Added a feature.\n"
+
+
+@pytest.mark.parametrize("version", ["v1.2.0", "1.2", "latest"])
+def test_extract_release_notes_rejects_invalid_version(version: str) -> None:
+    with pytest.raises(ValueError, match="must match X.Y.Z"):
+        extract_release_notes(CHANGELOG, version)
+
+
+def test_extract_release_notes_rejects_missing_version() -> None:
+    with pytest.raises(ValueError, match="found 0"):
+        extract_release_notes(CHANGELOG, "2.0.0")
+
+
+def test_extract_release_notes_rejects_duplicate_version() -> None:
+    duplicate = f"{CHANGELOG}\n## Version 1.2.0\n\nDuplicate.\n"
+
+    with pytest.raises(ValueError, match="found 2"):
+        extract_release_notes(duplicate, "1.2.0")
+
+
+def test_extract_release_notes_rejects_empty_section() -> None:
+    changelog = "## Version 2.0.0\n\n---\n\n## Version 1.0.0\n\nOld.\n"
+
+    with pytest.raises(ValueError, match="is empty"):
+        extract_release_notes(changelog, "2.0.0")


### PR DESCRIPTION
## Summary

- publish GitHub Release notes from the exact `CHANGELOG.md` version section and fail on missing, duplicate, or empty sections
- isolate the TestPyPI wheel download from dependency resolution, compare it byte-for-byte with the build artifact, and install dependencies only from PyPI
- generate and verify `SHA256SUMS` before both package-index uploads and attach it to the GitHub Release
- document the complete release audit, external configuration snapshot, prioritized risks, and partial-publication recovery matrix

The existing v0.5.0 GitHub Release has also been repaired with its complete changelog section and a checksum asset. No package files or tags were changed.

## Scope decisions

- artifact attestations and SBOMs are documented as deferred rather than added now
- final-PyPI download verification, global release concurrency, action SHA pinning, and versioned docs have explicit trigger points in `RELEASE_AUDIT.md`

## Validation

- `ruff check` and `ruff format --check`
- 264 tests passed, 1 skipped; coverage 65.18%
- Sphinx warnings-as-errors build passed
- PEP 517 wheel and sdist build passed
- Twine metadata checks passed
- release-note extractor edge cases: 7 tests passed
- local workflow YAML parse passed
